### PR TITLE
Add `webhook_sender_blocklist` variable

### DIFF
--- a/deploy/aws/variables.tf
+++ b/deploy/aws/variables.tf
@@ -92,6 +92,11 @@ variable "webhook_repo_blocklist" {
   type        = list(string)
   description = "List of org/repo names to always ignore in webhook processing"
 }
+variable "webhook_sender_blocklist" {
+  default     = []
+  type        = list(string)
+  description = "List of additional instances/apps/senders to always ignore in webhook processing"
+}
 
 variable "pullapprove_version" {
   default     = "3.11.0"

--- a/deploy/aws/webhook.tf
+++ b/deploy/aws/webhook.tf
@@ -10,16 +10,17 @@ resource "aws_lambda_function" "pullapprove_webhook" {
 
   environment {
     variables = {
-      AWS_SSM_PARAMETER_PATH = "/pullapprove${var.aws_unique_suffix}"
-      AWS_SQS_NAME           = aws_sqs_queue.pullapprove_worker_queue.name
-      GITHUB_STATUS_CONTEXT  = var.github_status_context
-      CONFIG_FILENAME        = var.config_filename
-      WEBHOOK_REPO_BLOCKLIST = join(",", var.webhook_repo_blocklist)
-      GITHUB_BOT_NAME        = var.github_bot_name
-      SENTRY_DSN             = var.sentry_dsn
-      SENTRY_ENVIRONMENT     = var.sentry_env
-      LOG_LEVEL              = var.log_level
-      VERSION                = var.pullapprove_version
+      AWS_SSM_PARAMETER_PATH   = "/pullapprove${var.aws_unique_suffix}"
+      AWS_SQS_NAME             = aws_sqs_queue.pullapprove_worker_queue.name
+      GITHUB_STATUS_CONTEXT    = var.github_status_context
+      CONFIG_FILENAME          = var.config_filename
+      WEBHOOK_REPO_BLOCKLIST   = join(",", var.webhook_repo_blocklist)
+      WEBHOOK_SENDER_BLOCKLIST = join(",", var.webhook_sender_blocklist)
+      GITHUB_BOT_NAME          = var.github_bot_name
+      SENTRY_DSN               = var.sentry_dsn
+      SENTRY_ENVIRONMENT       = var.sentry_env
+      LOG_LEVEL                = var.log_level
+      VERSION                  = var.pullapprove_version
     }
   }
 }


### PR DESCRIPTION
Still needs to be implemented in the webhook function itself, but this could provide a way to ignore additional instances of PullApprove (for testing, staging, etc.).